### PR TITLE
templates/layout: remove capitalize filter from domain name

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="en">
-	<title>{{config.DOMAIN|capitalize}} looking glass</title>
+	<title>{{config.DOMAIN}} looking glass</title>
 	<head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width,initial-scale=1">
@@ -16,7 +16,7 @@
 			</button>
 
 			<div class="collapse navbar-collapse" id="navbarSupportedContent">
-				<a class="navbar-brand" href="/">{{config.DOMAIN|capitalize}}</a>
+				<a class="navbar-brand" href="/">{{config.DOMAIN}}</a>
 				<ul class="nav nav-pills">
 					<li class="nav-item hosts mr-1"><a class="nav-link" id="all" href="#">all</a></li>
 


### PR DESCRIPTION
Domains are case insensitive by nature, so I suppose those who want it capitalized can set it in the config directly. I personally just don't like seeing my moniker capitalized. :)